### PR TITLE
Fixed error for windows, where it was not able to find any folders

### DIFF
--- a/Editor/GenerateFileEditorWindow.cs
+++ b/Editor/GenerateFileEditorWindow.cs
@@ -299,7 +299,7 @@ namespace ElRaccoone.EntityComponentSystem.Editor {
     private string FindDirectoryWithName (string directory, string name) {
       var _directories = this.WalkDirectory (directory);
       foreach (var _directory in _directories)
-        if (_directory.Split ('/').Last ().ToLower () == name.ToLower ())
+        if (Path.GetFileName(_directory)?.ToLower() == name.ToLower())
           return _directory;
       Debug.LogWarning ("There is no directory named '" + name + "', creating in project root.");
       return directory;

--- a/Editor/GenerateFileEditorWindow.cs
+++ b/Editor/GenerateFileEditorWindow.cs
@@ -299,7 +299,7 @@ namespace ElRaccoone.EntityComponentSystem.Editor {
     private string FindDirectoryWithName (string directory, string name) {
       var _directories = this.WalkDirectory (directory);
       foreach (var _directory in _directories)
-        if (Path.GetFileName(_directory)?.ToLower() == name.ToLower())
+        if (Path.GetFileName(_directory)?.ToLower () == name.ToLower ())
           return _directory;
       Debug.LogWarning ("There is no directory named '" + name + "', creating in project root.");
       return directory;


### PR DESCRIPTION
Fixed issue for finding directory names, where it was not OS agnostic.
Windows uses backslashes, UNIX based OS (Mac/Linux) uses regular slashes