### PR TITLE
Add isInitialized check to OnDestroy() in EntityComponent

### DIFF
--- a/Runtime/EntityComponent.cs
+++ b/Runtime/EntityComponent.cs
@@ -114,6 +114,8 @@ namespace ElRaccoone.EntityComponentSystem {
     /// Event invoked by the Unity Engine when the component is destroyed.
     /// </summary>
     void OnDestroy () {
+      if (!isInitialized)
+        return;
       var system = GetSystem ();
       // Remove the entity from the system.
       system.RemoveEntry ((EntityComponentType)this);


### PR DESCRIPTION
OnDestroy can still get called on components that are disabled by default (have never been activated)

In some cases this causes a race condition where the system has already been destroyed when OnDestroy() is called.
It may be that inactive components (that have never been activated) have a different execution order.
